### PR TITLE
MQTT client constructor now uses SSL context object

### DIFF
--- a/iotc/__init__.py
+++ b/iotc/__init__.py
@@ -4,6 +4,7 @@ import ure
 import json
 from utime import time,sleep
 import gc
+import ssl
 try:
     from umqtt.robust import MQTTClient
 except:
@@ -103,7 +104,7 @@ class IoTCClient():
             self._id_scope, self._device_id, self._credentials_type,self._credentials,self._logger,self._model_id)
         creds = prov.register()
         self._mqtt_client = MQTTClient(self._device_id, creds.host, 8883, creds.user.encode(
-            'utf-8'), creds.password.encode('utf-8'), ssl=True, keepalive=60)
+            'utf-8'), creds.password.encode('utf-8'), ssl=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT), keepalive=60)
         self._commands_regex = ure.compile(
             '\$iothub\/methods\/POST\/(.+)\/\?\$rid=(.+)')
         self._mqtt_client.connect(False)


### PR DESCRIPTION
Quick fix to address the changes introduced into mqtt.simple with [this commit](https://github.com/micropython/micropython-lib/commit/35d41dbb0e4acf1518f520220d405ebe2db257d6)